### PR TITLE
[ICC-22] mysql 도커 컴포즈 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### Custom ###
 **/src/main/resources/**secret**
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  q-asker-test-db:
+    image: mysql:8.0.35
+    container_name: q-asker-test-db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    expose:
+      - "3306"
+    ports:
+      - "3306:3306"
+    volumes:
+      - q-asker-test-db:/var/lib/mysql
+
+volumes:
+  q-asker-test-db:


### PR DESCRIPTION
## 📢 설명
docker desktop 설치
제가 windows버전은 잘 몰라서 양해부탁드립니다
포트가 3306인데 변경 필요하면 말씀부탁드립니다

```MYSQL_ROOT_PASSWORD```: 
MySQL 데이터베이스의 루트(root) 사용자를 위한 비밀번호입니다. 이 비밀번호는 MySQL 컨테이너가 시작될 때 루트 계정에 설정됩니다. 예: ${MYSQL_ROOT_PASSWORD}는 환경 변수나 .env 파일에서 정의된 값으로 대체됩니다.
```MYSQL_DATABASE```: 
MySQL 컨테이너가 시작될 때 자동으로 생성될 데이터베이스의 이름입니다. 이 설정을 통해 컨테이너가 초기화될 때 지정된 이름의 데이터베이스를 미리 생성할 수 있습니다.
```MYSQL_USER```:
 MySQL에 생성될 비루트(non-root) 사용자의 이름입니다. 이 사용자는 지정된 데이터베이스에 접근할 수 있는 권한을 가집니다.
```MYSQL_PASSWORD```:
 MYSQL_USER로 지정된 사용자의 비밀번호입니다. 이 비밀번호는 해당 사용자가 데이터베이스에 로그인할 때 사용됩니다.

## ✅ 체크 리스트
- [x] 노션 - 환경 변수 - API들어가서 .env와 동일하게 루트 경로에 .env 생성/변경
- [x] ```docker compose up -d```로 mysql 컨테이너 올라가는지 확인 안되면 ```docker-compose up -d``` 로 시도
