### PR TITLE
[ICC-44] 정수형 id 해시화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ dependencies {
     // webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-
+    // hash
+    implementation 'org.hashids:hashids:1.0.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/icc/qasker/global/config/FileUploadConfig.java
+++ b/src/main/java/com/icc/qasker/global/config/FileUploadConfig.java
@@ -1,4 +1,4 @@
-package com.icc.qasker.aws.config;
+package com.icc.qasker.global.config;
 
 import com.icc.qasker.aws.util.FileUploadValidator;
 import com.icc.qasker.aws.util.FileUrlValidator;

--- a/src/main/java/com/icc/qasker/global/config/HashIdConfig.java
+++ b/src/main/java/com/icc/qasker/global/config/HashIdConfig.java
@@ -1,0 +1,21 @@
+package com.icc.qasker.global.config;
+
+import org.hashids.Hashids;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HashIdConfig {
+
+    @Value("${app.hashids.salt}")
+    private String salt;
+
+    @Value("${app.hashids.min-length}")
+    private int minLength;
+
+    @Bean
+    public Hashids hashids() {
+        return new Hashids(salt, minLength);
+    }
+}

--- a/src/main/java/com/icc/qasker/global/util/HashUtil.java
+++ b/src/main/java/com/icc/qasker/global/util/HashUtil.java
@@ -1,0 +1,28 @@
+package com.icc.qasker.global.util;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class HashUtil {
+
+    private final org.hashids.Hashids hashids;
+
+    public String encode(long id) {
+        return hashids.encode(id);
+    }
+
+    public long decode(String hashId) {
+        long[] decoded = hashids.decode(hashId);
+        if (decoded.length == 0) {
+            throw new IllegalArgumentException("Invalid hash ID: " + hashId);
+        }
+        if (decoded.length > 1) {
+            log.error("중복된 ID가 발견되었습니다: {}", hashId);
+        }
+        return decoded[decoded.length - 1];
+    }
+}

--- a/src/main/java/com/icc/qasker/quiz/controller/ExplanationController.java
+++ b/src/main/java/com/icc/qasker/quiz/controller/ExplanationController.java
@@ -1,23 +1,24 @@
 package com.icc.qasker.quiz.controller;
 
 import com.icc.qasker.quiz.dto.response.ExplanationResponse;
-import com.icc.qasker.quiz.dto.response.ResultResponse;
 import com.icc.qasker.quiz.service.ExplanationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/explanation")
 public class ExplanationController {
+
     private final ExplanationService explanationService;
 
     @GetMapping("/{id}")
-    public ResponseEntity<ExplanationResponse> getExplanation(@PathVariable("id") Long problemSetId) {
-        List<ResultResponse> results = explanationService.getExplanationByProblemSetId(problemSetId);
-        return ResponseEntity.ok(new ExplanationResponse(results));
+    public ResponseEntity<ExplanationResponse> getExplanation(
+        @PathVariable("id") Long problemSetId) {
+        return ResponseEntity.ok(explanationService.getExplanationByProblemSetId(problemSetId));
     }
 }

--- a/src/main/java/com/icc/qasker/quiz/controller/ProblemSetController.java
+++ b/src/main/java/com/icc/qasker/quiz/controller/ProblemSetController.java
@@ -18,7 +18,7 @@ public class ProblemSetController {
 
     @GetMapping("/{id}")
     public ResponseEntity<ProblemSetResponse> getProblemSet(
-        @PathVariable("id") Long problemSetId) {
+        @PathVariable("id") String problemSetId) {
         return ResponseEntity.ok(problemSetService.getProblemSet(problemSetId));
     }
 }

--- a/src/main/java/com/icc/qasker/quiz/service/ExplanationService.java
+++ b/src/main/java/com/icc/qasker/quiz/service/ExplanationService.java
@@ -1,34 +1,31 @@
 package com.icc.qasker.quiz.service;
 
+import com.icc.qasker.quiz.dto.response.ExplanationResponse;
 import com.icc.qasker.quiz.dto.response.ResultResponse;
-import com.icc.qasker.global.error.CustomException;
-import com.icc.qasker.global.error.ExceptionMessage;
-import com.icc.qasker.quiz.repository.ProblemRepository;
 import com.icc.qasker.quiz.entity.Problem;
-import com.icc.qasker.quiz.entity.Selection;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
+import com.icc.qasker.quiz.repository.ProblemRepository;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ExplanationService {
+
     private final ProblemRepository problemRepository;
 
-    public List<ResultResponse> getExplanationByProblemSetId(Long problemSetId) {
+    public ExplanationResponse getExplanationByProblemSetId(Long problemSetId) {
         List<Problem> problems = problemRepository.findByIdProblemSetId(problemSetId);
         List<ResultResponse> results = new ArrayList<>();
 
         for (Problem problem : problems) {
             String explanation = (problem.getExplanation() != null)
-                    ? problem.getExplanation().getContent()
-                    : "해설 없음";
+                ? problem.getExplanation().getContent()
+                : "해설 없음";
             results.add(new ResultResponse(problem.getId().getNumber(), explanation));
         }
 
-        return results;
+        return new ExplanationResponse(results);
     }
 }

--- a/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
+++ b/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
@@ -31,8 +31,6 @@ public class GenerationService {
 
     private final WebClient aiWebClient;
     private final ProblemSetRepository problemSetRepository;
-    private final SelectionRepository selectionRepository;
-    private final ProblemRepository problemRepository;
 
     public GenerationService(
         @Qualifier("aiWebClient") WebClient aiWebClient,
@@ -42,8 +40,6 @@ public class GenerationService {
     ) {
         this.aiWebClient = aiWebClient;
         this.problemSetRepository = problemSetRepository;
-        this.selectionRepository = selectionRepository;
-        this.problemRepository = problemRepository;
     }
 
     public Mono<ProblemSetResponse> processGenerationRequest(

--- a/src/main/java/com/icc/qasker/quiz/service/ProblemSetService.java
+++ b/src/main/java/com/icc/qasker/quiz/service/ProblemSetService.java
@@ -2,22 +2,27 @@ package com.icc.qasker.quiz.service;
 
 import com.icc.qasker.global.error.CustomException;
 import com.icc.qasker.global.error.ExceptionMessage;
+import com.icc.qasker.global.util.HashUtil;
 import com.icc.qasker.quiz.dto.response.ProblemSetResponse;
 import com.icc.qasker.quiz.entity.ProblemSet;
 import com.icc.qasker.quiz.repository.ProblemSetRepository;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class ProblemSetService {
 
     private final ProblemSetRepository problemSetRepository;
+    private final HashUtil hashUtil;
 
-    public ProblemSetResponse getProblemSet(Long problemSetId) {
-        ProblemSet problemSet = problemSetRepository.getProblemSetById(problemSetId).orElseThrow(
-            () -> new CustomException(ExceptionMessage.PROBLEM_SET_NOT_FOUND)
-        );
+    public ProblemSetResponse getProblemSet(String problemSetId) {
+
+        long id = hashUtil.decode(problemSetId);
+        ProblemSet problemSet = problemSetRepository.getProblemSetById(id)
+            .orElseThrow(
+                () -> new CustomException(ExceptionMessage.PROBLEM_SET_NOT_FOUND)
+            );
         return ProblemSetResponse.of(problemSet);
     }
 }


### PR DESCRIPTION
## 📢 설명
FileUploadConfig를 global.config 패키지로 이동하였습니다

현재 문제세트는 정수형 id를 가지고있어 1, 2, 3,..,으로 접근합니다
그러면 사용자도 1, 2, 3,.. 으로 쉽게 추정하여 어떤 리소스에든 접근할 수 있는 문제가 있습니다
따라서 데이터베이스에는 정수id를 유지하되, 사용자 요청은 암호화된 문자열로 받는 구조로 변경하였습니다

- 기존 ```Long problemSetId```를 ```String problemSetId```로 변경
  ```
  @GetMapping("/{id}")
      public ResponseEntity<ProblemSetResponse> getProblemSet(
          @PathVariable("id") String problemSetId) {
          return ResponseEntity.ok(problemSetService.getProblemSet(problemSetId));
      }
  ```

- 정수형 id를 가져올 때는 hashUtil.decode 수행
  ```
  long id = hashUtil.decode(problemSetId);
  ```

- ```HashUtil```
  HashIdConfig의 아래의 값을 참조하여 인코딩/디코딩 수행
  ```
  @Value("${app.hashids.salt}")
  private String salt;
  
  @Value("${app.hashids.min-length}")
  private int minLength;
  ```
  decode 메서드: 문자열을 정수로 변환
  encode 메서드: 정수를 문자열로 변환

## ✅ 체크 리스트

- [ ] 노션 - 테스트 - api서버의 해시값 이용하여 존재하는 id에 대해 테스트
- [ ] 코드 리뷰