### PR TITLE
[ICC-45] FE Generation service 응답 형식 변경

### DIFF
--- a/src/main/java/com/icc/qasker/quiz/controller/GenerationController.java
+++ b/src/main/java/com/icc/qasker/quiz/controller/GenerationController.java
@@ -2,6 +2,7 @@ package com.icc.qasker.quiz.controller;
 
 import com.icc.qasker.quiz.controller.doc.GenerationApiDoc;
 import com.icc.qasker.quiz.dto.request.FeGenerationRequest;
+import com.icc.qasker.quiz.dto.response.GenerationResponse;
 import com.icc.qasker.quiz.dto.response.ProblemSetResponse;
 import com.icc.qasker.quiz.service.GenerationService;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ public class GenerationController implements GenerationApiDoc {
     private final GenerationService generationService;
 
     @PostMapping
-    public Mono<ProblemSetResponse> postQuiz(@RequestBody FeGenerationRequest feGenerationRequest) {
+    public Mono<GenerationResponse> postQuiz(@RequestBody FeGenerationRequest feGenerationRequest) {
         return generationService.processGenerationRequest(feGenerationRequest);
     }
 

--- a/src/main/java/com/icc/qasker/quiz/controller/doc/GenerationApiDoc.java
+++ b/src/main/java/com/icc/qasker/quiz/controller/doc/GenerationApiDoc.java
@@ -1,6 +1,7 @@
 package com.icc.qasker.quiz.controller.doc;
 
 import com.icc.qasker.quiz.dto.request.FeGenerationRequest;
+import com.icc.qasker.quiz.dto.response.GenerationResponse;
 import com.icc.qasker.quiz.dto.response.ProblemSetResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,5 +14,5 @@ public interface GenerationApiDoc {
 
     @Operation(summary = "문제를 생성한다")
     @PostMapping
-    Mono<ProblemSetResponse> postQuiz(@RequestBody FeGenerationRequest feGenerationRequest);
+    Mono<GenerationResponse> postQuiz(@RequestBody FeGenerationRequest feGenerationRequest);
 }

--- a/src/main/java/com/icc/qasker/quiz/dto/response/GenerationResponse.java
+++ b/src/main/java/com/icc/qasker/quiz/dto/response/GenerationResponse.java
@@ -1,0 +1,16 @@
+package com.icc.qasker.quiz.dto.response;
+
+import com.icc.qasker.quiz.entity.ProblemId;
+import com.icc.qasker.quiz.service.GenerationService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.bind.annotation.GetMapping;
+@Getter
+@AllArgsConstructor
+public class GenerationResponse {
+    private Long problemSetId;
+    public static GenerationResponse of(Long problemSetId){
+        return new GenerationResponse(problemSetId);
+    }
+
+}

--- a/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
+++ b/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
@@ -4,7 +4,7 @@ import com.icc.qasker.global.error.CustomException;
 import com.icc.qasker.global.error.ExceptionMessage;
 import com.icc.qasker.quiz.dto.request.FeGenerationRequest;
 import com.icc.qasker.quiz.dto.response.AiGenerationResponse;
-import com.icc.qasker.quiz.dto.response.ProblemSetResponse;
+import com.icc.qasker.quiz.dto.response.GenerationResponse;
 import com.icc.qasker.quiz.dto.response.QuizGeneratedByAI;
 import com.icc.qasker.quiz.entity.Explanation;
 import com.icc.qasker.quiz.entity.Problem;
@@ -42,11 +42,11 @@ public class GenerationService {
         this.problemSetRepository = problemSetRepository;
     }
 
-    public Mono<ProblemSetResponse> processGenerationRequest(
+    public Mono<GenerationResponse> processGenerationRequest(
         FeGenerationRequest feGenerationRequest) {
         return callAiServer(feGenerationRequest)
             .flatMap(aiResponse -> saveToDB(aiResponse, feGenerationRequest.getQuizCount()))
-            .map(this::convertToFeResponse)
+                .map(problemSet -> convertToFeResponse(problemSet.getId()))
             .doOnError(error -> {
                 log.error("예외 발생: {}", error.getMessage(), error);
             })
@@ -123,8 +123,8 @@ public class GenerationService {
         return problem;
     }
 
-    private ProblemSetResponse convertToFeResponse(ProblemSet problemSet) {
-        return ProblemSetResponse.of(problemSet);
+    private GenerationResponse convertToFeResponse(Long problemSetId) {
+        return GenerationResponse.of(problemSetId);
     }
 
     // for error


### PR DESCRIPTION
## 📢 설명

FE 문제 생성 요청 시 기존 전체 문제집 반환에서 problem_set_id 응답으로 변경한 코드입니다.
추가로 지정 url이외 요청 시 에러 발생 코드 추가했습니다. 

## ✅ 체크 리스트

- [ ] 