### PR TITLE
[ICC-51] AI서버 연결 간 문제 해결

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -63,7 +63,7 @@ jobs:
       DOCKER_IMAGE_NAME: ${{ secrets.DOCKER_IMAGE_NAME }}
       # Spring Boot 관련
       MYSQL_URL: ${{ secrets.MYSQL_URL }}
-      FRONTEND_URL: https://q-asker.com
+      FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
       AI_SERVER_URL: ${{ secrets.AI_SERVER_URL }}
       # DB 관련
       DATASOURCE_USERNAME: ${{ secrets.DATASOURCE_USERNAME }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,5 @@ services:
     volumes:
       - q-asker-test-db:/var/lib/mysql
 
-
 volumes:
   q-asker-test-db:

--- a/src/main/java/com/icc/qasker/global/config/SwaggerConfig.java
+++ b/src/main/java/com/icc/qasker/global/config/SwaggerConfig.java
@@ -3,21 +3,11 @@ package com.icc.qasker.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.servers.Server;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
-
-    Server local = new Server()
-        .url("http://localhost:8080")
-        .description("로컬 개발 서버");
-
-    Server prod = new Server()
-        .url("https://api.yourdomain.com")
-        .description("프로덕션 서버");
 
     Info info = new Info()
         .title("q-asker API 문서");
@@ -25,7 +15,6 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI().components(new Components())
-            .servers(List.of(local, prod))
             .info(info);
     }
 }

--- a/src/main/java/com/icc/qasker/global/config/WebClientConfig.java
+++ b/src/main/java/com/icc/qasker/global/config/WebClientConfig.java
@@ -6,15 +6,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
+
 @Configuration
 public class WebClientConfig {
-    @Value("${q-asker.ai-url}")
+
+    @Value("${q-asker.ai-server-url}")
     private String aiServerUrl;
+
     @Bean("aiWebClient")
     public WebClient aiWebClient(WebClient.Builder builder) {
         return builder
-                .baseUrl(aiServerUrl)
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .build();
+            .baseUrl(aiServerUrl)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
     }
 }

--- a/src/main/java/com/icc/qasker/quiz/controller/ExplanationController.java
+++ b/src/main/java/com/icc/qasker/quiz/controller/ExplanationController.java
@@ -3,7 +3,6 @@ package com.icc.qasker.quiz.controller;
 import com.icc.qasker.quiz.controller.doc.ExplanationApiDoc;
 import com.icc.qasker.quiz.dto.response.ExplanationResponse;
 import com.icc.qasker.quiz.service.ExplanationService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +19,7 @@ public class ExplanationController implements ExplanationApiDoc {
 
     @GetMapping("/{id}")
     public ResponseEntity<ExplanationResponse> getExplanation(
-        @PathVariable("id") Long problemSetId) {
+        @PathVariable("id") String problemSetId) {
         return ResponseEntity.ok(explanationService.getExplanationByProblemSetId(problemSetId));
     }
 }

--- a/src/main/java/com/icc/qasker/quiz/controller/doc/ExplanationApiDoc.java
+++ b/src/main/java/com/icc/qasker/quiz/controller/doc/ExplanationApiDoc.java
@@ -13,5 +13,5 @@ public interface ExplanationApiDoc {
     @Operation(summary = "설명을 가져온다")
     @GetMapping("/{id}")
     ResponseEntity<ExplanationResponse> getExplanation(
-        @PathVariable("id") Long problemSetId);
+        @PathVariable("id") String problemSetId);
 }

--- a/src/main/java/com/icc/qasker/quiz/dto/response/AiGenerationResponse.java
+++ b/src/main/java/com/icc/qasker/quiz/dto/response/AiGenerationResponse.java
@@ -2,18 +2,17 @@ package com.icc.qasker.quiz.dto.response;
 
 import com.icc.qasker.global.error.CustomException;
 import com.icc.qasker.global.error.ExceptionMessage;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 import java.util.List;
+import lombok.Getter;
+
 @Getter
 public class AiGenerationResponse {
+
     private String title;
     private List<QuizGeneratedByAI> quiz;
+
     public AiGenerationResponse(String title, List<QuizGeneratedByAI> quiz) {
-        if (title == null || title.trim().isEmpty() || quiz == null || quiz.isEmpty()) {
+        if (quiz == null || quiz.isEmpty()) {
             throw new CustomException(ExceptionMessage.INVALID_AI_RESPONSE);
         }
         for (QuizGeneratedByAI q : quiz) {

--- a/src/main/java/com/icc/qasker/quiz/repository/ProblemRepository.java
+++ b/src/main/java/com/icc/qasker/quiz/repository/ProblemRepository.java
@@ -2,13 +2,11 @@ package com.icc.qasker.quiz.repository;
 
 import com.icc.qasker.quiz.entity.Problem;
 import com.icc.qasker.quiz.entity.ProblemId;
-import com.icc.qasker.quiz.entity.ProblemSet;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface ProblemRepository extends JpaRepository<Problem, ProblemId> {
-    List<Problem> findByProblemSet(ProblemSet problemSet);
+
     List<Problem> findByIdProblemSetId(Long problemSetId);
 
 }

--- a/src/main/java/com/icc/qasker/quiz/service/ExplanationService.java
+++ b/src/main/java/com/icc/qasker/quiz/service/ExplanationService.java
@@ -1,5 +1,8 @@
 package com.icc.qasker.quiz.service;
 
+import com.icc.qasker.global.error.CustomException;
+import com.icc.qasker.global.error.ExceptionMessage;
+import com.icc.qasker.global.util.HashUtil;
 import com.icc.qasker.quiz.dto.response.ExplanationResponse;
 import com.icc.qasker.quiz.dto.response.ResultResponse;
 import com.icc.qasker.quiz.entity.Problem;
@@ -13,12 +16,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ExplanationService {
 
+    private final HashUtil hashUtil;
     private final ProblemRepository problemRepository;
 
-    public ExplanationResponse getExplanationByProblemSetId(Long problemSetId) {
-        List<Problem> problems = problemRepository.findByIdProblemSetId(problemSetId);
-        List<ResultResponse> results = new ArrayList<>();
+    public ExplanationResponse getExplanationByProblemSetId(String problemSetId) {
+        long id = hashUtil.decode(problemSetId);
+        List<Problem> problems = problemRepository.findByIdProblemSetId(id);
+        if (problems.isEmpty()) {
+            throw new CustomException(ExceptionMessage.PROBLEM_NOT_FOUND);
+        }
 
+        List<ResultResponse> results = new ArrayList<>();
         for (Problem problem : problems) {
             String explanation = (problem.getExplanation() != null)
                 ? problem.getExplanation().getContent()


### PR DESCRIPTION
## 📢 설명
### 코드 변경사항
- 스웨거가 현재 요청한 호스트 주소를 매핑해주니 불필요한 도메인 지정 제거
- ```@Value("${q-asker.ai-url}")```를 ```@Value("${q-asker.ai-server-url}")```로 변경: 바꾼 이유
    1. workflows에는 q-asker.ai-server-url로 되어있음
    2. 연결된 변수 이름이 aiServerUrl임
- title을 안주기로 했으므로 title관련 검사 제거 title은 null로 들어옴
- 타임아웃 속성 제거
    - 타임아웃은 LLM이 문제를 생성하는 도중 문제가 생기면 발생할 것입니다 LLM과 직접 닿아있는 AI 서버가 타임아웃 정책을 관리하는 것이 좋아보여서 제거하였습니다 이렇게하면 AI Server한 곳에서만 타임아웃을 관리하면 된다는 장점이 있습니다
- 추가) 깃허브 액션 수행시 frontend-url도 환경변수로 받게 했습니다 
### application-secret.yml  변경사항
- ai-server-url 변경
-  로컬 application-secret를 복사 붙여넣기 하는 방식으로  개발서버 환경 변수를 지정하는데 create로 지정하면 실수로 개발서버 데이터가 초기화될 우려가 있으므로 아래와 같이 변경
```
jpa:
    hibernate:
      ddl-auto: update
```
- init.sql을 사용하지 않으므로 아래 속성 제거
```
sql:
    init:
      mode: always
defer-datasource-initialization: true
```
- 타임아웃 정책을 적용하지 않기로 했으므로 아래와 같이 속성 지정 
```
spring:
  mvc:
    async:
      request-timeout: -1 
```
### 참고 사항
- 개행 등 포맷 수정사항은 포맷터가 알아서 해준거라 이해 부탁드립니다 
- 현재 요청할 때 카멜 케이스가 스네이크 케이스로 자동으로 변경되지 않아 ai 서버쪽 요청 dto를 카멜케이스로 변경하고있습니다 자동 변경을 위해선 추가 설정이 필요해 보입니다 
- AI서버에서는 퀴즈 개수를 5의 배수만을 생각하고있으므로 요청시 quizCount를 5의 배수로 지정하지 않으면 ```aiResponse.getQuiz().size() != feRequestQuizCount```로직에 의해 오류가 생깁니다 프론트엔드도 확인 결과 현재 퀴즈 수를 현재 5의 배수만을 생각하고있습니다 추후 논의가 필요해보입니다

## ✅ 체크 리스트
- [x] 노션 참고하여 ```application-secret.yml``` 업데이트
- [x] postman에서 퀴즈 생성 - 문제 세트 가져오기 한 사이클 수행하고 문제 없는지 확인
- [x] 코드 리뷰