### PR TITLE
[ICC-52] 연결 수정 사항 추가

### DIFF
--- a/src/main/java/com/icc/qasker/quiz/dto/request/FeGenerationRequest.java
+++ b/src/main/java/com/icc/qasker/quiz/dto/request/FeGenerationRequest.java
@@ -22,9 +22,13 @@ public class FeGenerationRequest {
         if (uploadedUrl == null && quizCount <= 0 && type == null) {
             throw new CustomException(ExceptionMessage.NULL_GENERATION_REQUEST);
         }
-        if (uploadedUrl == null || uploadedUrl.trim().isEmpty() || quizCount <= 0 || type == null) {
+        if (uploadedUrl == null || uploadedUrl.trim().isEmpty()
+                || quizCount <= 0 || quizCount % 5 != 0
+                || type == null) {
             throw new CustomException(ExceptionMessage.INVALID_FE_REQUEST);
         }
+
+
         this.uploadedUrl = uploadedUrl;
         this.quizCount = quizCount;
         this.type = type;

--- a/src/main/java/com/icc/qasker/quiz/dto/response/ProblemSetResponse.java
+++ b/src/main/java/com/icc/qasker/quiz/dto/response/ProblemSetResponse.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProblemSetResponse {
 
-    private Long problemSetId;
     private String title;
     private List<QuizForFe> quiz;
 
@@ -25,7 +24,6 @@ public class ProblemSetResponse {
             .toList();
 
         return new ProblemSetResponse(
-            problemSet.getId(),
             problemSet.getTitle(),
             quizzes
         );


### PR DESCRIPTION
## 📢 설명

다음 사항 추가했습니다
- ```problem_set get``` get 요청 응답 변경
- ```quizCount``` 관련 에러 처리 

## ✅ 체크 리스트

- [x] postman - 퀴즈 생성 시 quizCount 5 배수 아닌 값 요청 시 응답 확인
- [x] 예상 응답
```
{
    "message": "유효하지 않은 요청입니다."
}
```
- [x] postman - 문제 세트 가져오기 실행 후 응답 확인 (problem_set_id 삭제)