### PR TITLE
[ICC-73] entity 관련 에러 수정

### DIFF
--- a/src/main/java/com/icc/qasker/quiz/dto/request/FeGenerationRequest.java
+++ b/src/main/java/com/icc/qasker/quiz/dto/request/FeGenerationRequest.java
@@ -4,6 +4,7 @@ import com.icc.qasker.global.error.CustomException;
 import com.icc.qasker.global.error.ExceptionMessage;
 import com.icc.qasker.quiz.domain.enums.DifficultyType;
 import com.icc.qasker.quiz.domain.enums.QuizType;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -15,6 +16,7 @@ public class FeGenerationRequest {
     @NotBlank(message = "url이 존재하지 않습니다.")
     private String uploadedUrl;
     @Min(value = 5, message = "quizCount는 5이상입니다.")
+    @Max(value = 50, message = "quizCount는 50이하입니다.")
     private int quizCount;
     @NotNull(message = "quizType이 null입니다.")
     private QuizType quizType;

--- a/src/main/java/com/icc/qasker/quiz/entity/Explanation.java
+++ b/src/main/java/com/icc/qasker/quiz/entity/Explanation.java
@@ -1,20 +1,32 @@
 package com.icc.qasker.quiz.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
-@Getter @NoArgsConstructor @Setter
+@Getter
+@NoArgsConstructor
+@Setter
 public class Explanation {
+
     @EmbeddedId
     private ProblemId id;
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @OneToOne
     @MapsId
     @JoinColumns({
-            @JoinColumn(name = "problem_set_id", referencedColumnName = "problem_set_id"),
-            @JoinColumn(name = "number", referencedColumnName = "number")
+        @JoinColumn(name = "problem_set_id", referencedColumnName = "problem_set_id"),
+        @JoinColumn(name = "number", referencedColumnName = "number")
     })
     private Problem problem;
 }

--- a/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
+++ b/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
@@ -7,7 +7,12 @@ import com.icc.qasker.quiz.dto.request.FeGenerationRequest;
 import com.icc.qasker.quiz.dto.response.AiGenerationResponse;
 import com.icc.qasker.quiz.dto.response.GenerationResponse;
 import com.icc.qasker.quiz.dto.response.QuizGeneratedByAI;
-import com.icc.qasker.quiz.entity.*;
+import com.icc.qasker.quiz.entity.Explanation;
+import com.icc.qasker.quiz.entity.Problem;
+import com.icc.qasker.quiz.entity.ProblemId;
+import com.icc.qasker.quiz.entity.ProblemSet;
+import com.icc.qasker.quiz.entity.ReferencedPage;
+import com.icc.qasker.quiz.entity.Selection;
 import com.icc.qasker.quiz.repository.ProblemSetRepository;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
@@ -90,7 +95,8 @@ public class GenerationService {
             if (aiResponse.getQuiz().size() != feRequestQuizCount) {
                 throw new CustomException(ExceptionMessage.INVALID_AI_RESPONSE);
             }
-            Set<ConstraintViolation<AiGenerationResponse>> violations = validator.validate(aiResponse);
+            Set<ConstraintViolation<AiGenerationResponse>> violations = validator.validate(
+                aiResponse);
             if (!violations.isEmpty()) {
                 throw new CustomException(ExceptionMessage.INVALID_AI_RESPONSE);
             }
@@ -135,7 +141,11 @@ public class GenerationService {
 
         // - 4. explanation
         Explanation explanation = new Explanation();
-        explanation.setContent(quiz.getExplanation());
+        String explanationContent = quiz.getExplanation();
+        if (explanationContent != null && explanationContent.length() > 200000) {
+            explanationContent = explanationContent.substring(0, 20000);
+        }
+        explanation.setContent(explanationContent);
         explanation.setProblem(problem);
         problem.setExplanation(explanation);
 


### PR DESCRIPTION
## 📢 설명

- Entity관련 에러 수정했습니다. 기존 ```"difficultyType": "STRATEGIC"```으로 요청 시 발생했던 오류는 다음과 같습니다. 
```Data truncation: Data too long for column 'content' at row 1```
이는 AI가 생성하는 해설의 길이가 길 때 발생하는 오류였고, 해결을 위해 entity에서 명시적으로 크기를 수정했습니다.
```@Column(columnDefinition = "TEXT")```의 경우 한글 200000자 정도 저장이 가능하다 하지만, 혹시 몰라 service에서 20000자 이상의 경우 자르는 로직을 추가햇습니다. 
- quizCount의 max값도 추가했습니다.

## ✅ 체크 리스트

- [ ] "difficultyType": "STRATEGIC"으로 요청 시 problem_set이 알맞게 응답오는 지 확인
- [ ] 코드 리뷰