### PR TITLE
[ICC-81] AI 응답 선지 순서 변경

### DIFF
--- a/src/main/java/com/icc/qasker/quiz/dto/response/AiGenerationResponse.java
+++ b/src/main/java/com/icc/qasker/quiz/dto/response/AiGenerationResponse.java
@@ -1,14 +1,8 @@
 package com.icc.qasker.quiz.dto.response;
 
-import com.icc.qasker.global.error.CustomException;
-import com.icc.qasker.global.error.ExceptionMessage;
-import java.util.List;
-
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/icc/qasker/quiz/dto/response/QuizGeneratedByAI.java
+++ b/src/main/java/com/icc/qasker/quiz/dto/response/QuizGeneratedByAI.java
@@ -1,18 +1,15 @@
 package com.icc.qasker.quiz.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
+import java.util.List;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
 @Getter
 public class QuizGeneratedByAI {
+
     @NotNull(message = "number가 null입니다.")
     private int number;
 
@@ -30,7 +27,9 @@ public class QuizGeneratedByAI {
     private List<Integer> referencedPages;
 
     @Getter
+    @Setter
     public static class SelectionsOfAi {
+
         @NotBlank(message = "selection의 content가 존재하지 않습니다.")
         private String content;
         private boolean correct;

--- a/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
+++ b/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
@@ -103,20 +103,7 @@ public class GenerationService {
                 throw new CustomException(ExceptionMessage.INVALID_AI_RESPONSE);
             }
             for (QuizGeneratedByAI quiz : aiResponse.getQuiz()) {
-                System.out.println("Before");
-                for (int i = 0; i < 4; i++) {
-                    QuizGeneratedByAI.SelectionsOfAi s = quiz.getSelections().get(i);
-                    System.out.println(
-                        "content: " + s.getContent() + ", correct: " + s.isCorrect());
-                }
-
                 Collections.shuffle(quiz.getSelections());
-
-                System.out.println("After shuffle:");
-                for (QuizGeneratedByAI.SelectionsOfAi s : quiz.getSelections()) {
-                    System.out.println(
-                        "content: " + s.getContent() + ", correct: " + s.isCorrect());
-                }
             }
 
             return saveProblemSet(aiResponse);

--- a/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
+++ b/src/main/java/com/icc/qasker/quiz/service/GenerationService.java
@@ -18,6 +18,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
@@ -100,6 +101,22 @@ public class GenerationService {
                 aiResponse);
             if (!violations.isEmpty()) {
                 throw new CustomException(ExceptionMessage.INVALID_AI_RESPONSE);
+            }
+            for (QuizGeneratedByAI quiz : aiResponse.getQuiz()) {
+                System.out.println("Before");
+                for (int i = 0; i < 4; i++) {
+                    QuizGeneratedByAI.SelectionsOfAi s = quiz.getSelections().get(i);
+                    System.out.println(
+                        "content: " + s.getContent() + ", correct: " + s.isCorrect());
+                }
+
+                Collections.shuffle(quiz.getSelections());
+
+                System.out.println("After shuffle:");
+                for (QuizGeneratedByAI.SelectionsOfAi s : quiz.getSelections()) {
+                    System.out.println(
+                        "content: " + s.getContent() + ", correct: " + s.isCorrect());
+                }
             }
 
             return saveProblemSet(aiResponse);


### PR DESCRIPTION
## 📢 설명

shuffle을 이용해서 선지 순서 변경했습니다.
추가로 선지의 순서를 BE에서 랜덤하게 변경하므로 프롬프트는 기존 상태로 바꾸는게 좋을 듯 합니다. 테스트 할 때 프롬프트 영향인지 낮은 레벨, 적은 문제 수로 해도 가끔 네트워크 에러가 나더라구요.

## ✅ 체크 리스트

- [ ] shuffle 결과 확인하기
```Collections.shuffle(quiz.getSelections());``` 위, 아래에 print문을 넣어서 확인 할 수 있습니다.
예상 결과
```
Before
content: SQL 쿼리에서 사용자 입력값에 대한 적절한 검증이 이루어지지 않는 것, correct: true
content: 데이터베이스 서버의 처리 속도가 느린 것, correct: false
content: SQL 문법이 복잡한 것, correct: false
content: 웹 애플리케이션의 용량이 큰 것, correct: false
After shuffle:
content: 웹 애플리케이션의 용량이 큰 것, correct: false
content: SQL 쿼리에서 사용자 입력값에 대한 적절한 검증이 이루어지지 않는 것, correct: true
content: 데이터베이스 서버의 처리 속도가 느린 것, correct: false
content: SQL 문법이 복잡한 것, correct: false
```
- [ ] 코드 리뷰