### PR TITLE
[ICC-95] 예외 메시지 반환 추가

### DIFF
--- a/src/main/java/com/icc/qasker/global/error/ExceptionMessage.java
+++ b/src/main/java/com/icc/qasker/global/error/ExceptionMessage.java
@@ -25,9 +25,11 @@ public enum ExceptionMessage {
     AI_SERVER_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "AI서버 응답 시간이 초과되었습니다."),
     AI_SERVER_CONNECTION_FAILED(HttpStatus.BAD_GATEWAY, "AI서버에 연결할 수 없습니다."),
     AI_SERVER_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI서버에서 오류가 발생했습니다."),
+    AI_SERVER_TO_MANY_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "서버가 생성요청 한도에 도달했습니다. 문제 개수를 줄이거나 1분 뒤 다시 시도해주세요."),
 
     NULL_AI_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답이 null입니다."),
     INVALID_AI_RESPONSE(HttpStatus.UNPROCESSABLE_ENTITY, "유효하지 않은 AI의 응답입니다."),
+
 
     // FE ISSUE
     // NULL_GENERATION_REQUEST(HttpStatus.BAD_REQUEST, "생성 요청이 null입니다."),


### PR DESCRIPTION
## 📢 설명 : https://github.com/Inha-cc-01/AI/pull/27 와 같이 리뷰 부탁드려요
AI 서버에서 반환하는 응답중 429 ratelimit에 대해서는 특별한 예외로 처리하고 특별한 응답을 반환하도록 하였습니다

## ✅ 체크 리스트
- [x] localhost:8000에 AI 서버 실행
- [ ] postman 퀴즈 생성 - Send - Cancel 계속 반복하면 아래와 같은 응답이 오는지 확인
![image](https://github.com/user-attachments/assets/04f97200-8432-4c8b-ad0f-02d8f983b5ee)
- [ ] 코드 리뷰